### PR TITLE
Fix bug when loading settings for contacts from the groups page.

### DIFF
--- a/includes/disciple-tools-maarifa-tile.php
+++ b/includes/disciple-tools-maarifa-tile.php
@@ -89,18 +89,14 @@ class Disciple_Tools_Maarifa_Tile
     public static function dt_maarifa_declare_section_id( $sections, $post_type = "" ) {
         //check if we are on a contact
         if ( $post_type === "contacts" ) {
-            $contact_fields = self::is_dt_1_0()
-                ? DT_Posts::get_post_field_settings( "contacts" )
-                : Disciple_Tools_Contact_Post_Type::instance()->get_custom_fields_settings();
-
-            //check if the language field is set
             //check if content is there before adding empty tile
             $contact_id    = get_the_ID();
             if ( $contact_id ){
-                $contact = self::is_dt_1_0()
-                    ? DT_Posts::get_post( "contacts", $contact_id, true, true )
-                    : Disciple_Tools_Contacts::get_contact( $contact_id, true, true );
-                if ( isset( $contact["maarifa_data"] ) ) {
+                $contact = DT_Posts::get_post( "contacts", $contact_id, true, true );
+                if ( !is_wp_error( $contact ) && isset( $contact["maarifa_data"] ) ) {
+                    $contact_fields = self::is_dt_1_0()
+                      ? DT_Posts::get_post_field_settings( "contacts" )
+                      : Disciple_Tools_Contact_Post_Type::instance()->get_custom_fields_settings();
                     if ( isset( $contact_fields["maarifa_data"] ) ) {
                         $sections[] = "contact_maarifa_data";
                     }


### PR DESCRIPTION
It was trying to load a group as a contact and then throwing an error.
Also DT_Posts::get_post(); is available before v1 so the logic can be simplified.